### PR TITLE
Mend autofix: smslegaltoolkit security updates

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,5 +1,4 @@
 {
-  "settingsInheritedFrom": "amsclark/mend-settings@main",
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure",
     "displayMode": "diff",


### PR DESCRIPTION
Closes #6

## Summary
- Removes the broken `settingsInheritedFrom` attribute from `.whitesource` that pointed to a non-existent repository (`amsclark/mend-settings@main`), which was blocking Mend scans.

## Test plan
- [ ] Mend can scan the repo again now that the inherited-settings pointer is gone.